### PR TITLE
Let csharp property set() occur once only (#4)

### DIFF
--- a/Client/Assets/Scripts/Baby/BabyInfo.cs
+++ b/Client/Assets/Scripts/Baby/BabyInfo.cs
@@ -1,46 +1,191 @@
 using System;
+using System.Linq;
 using System.Collections;
 using System.Collections.Generic;
+using UnityEngine;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using Module;
 
 namespace Baby 
 {
     public class BabyInfo
     {
+        private string id;
+        private string name;
+        private Dictionary<string, int> level;
+        private Decimal weight;
+        private Dictionary<string, Decimal> temperament;
+        private Dictionary<string, Dictionary<string, int>> appearance;
+        private WriteOnce writeOnce = new WriteOnce();
+
         public string ID
         {
-            get; set;
+            get
+            {
+                return id;
+            }
+
+            set
+            {
+                if (writeOnce.isAlreadyWrite("ID"))
+                {
+                    throw new InvalidOperationException("Value already set");
+                }
+
+                id = value;
+                writeOnce.AlreadyWrite("ID");
+            }
         }
 
+        // automatic property. 
+        // 보통은 private변수를 따로 두고 이에 대한 get,set을 관리하는 public property가 있음(위 ID처럼)
         public string Name
         {
-            get; set;
+            get
+            {
+                return name;
+            }
+
+            set
+            {
+                if (writeOnce.isAlreadyWrite("Name"))
+                {
+                    throw new InvalidOperationException("Value already set");
+                }
+
+                name = value;
+                writeOnce.AlreadyWrite("Name");
+            }
         }
 
-        public int Months
+        public uint Months
         {
             get; set;
         }
 
         public Dictionary<string, int> Level
         {
-            get; set;
+            get
+            {
+                return level;
+            }
+
+            set
+            {
+                if (writeOnce.isAlreadyWrite("Level"))
+                {
+                    throw new InvalidOperationException
+                    (
+                        "Use `'UpdateLevel(string, int)`'"
+                    );
+                }
+
+                level = value;
+                writeOnce.AlreadyWrite("Level");
+            }
+        }
+
+        public void UpdateLevel(string skill, int value)
+        {
+            string[] skills = { "toilet", "walking", "speaking" };
+
+            if (skills.Any(skill.Contains))
+            {
+                level[skill] = value;
+            }
+            else
+            {
+                throw new FormatException("Invalid skill");
+            }
         }
 
         public Decimal Weight
         {
-            get; set;
+            get
+            {
+                return weight;
+            }
+            set
+            {
+                if (value < 0)
+                {
+                    throw new ArgumentOutOfRangeException
+                    (
+                        "Weight must be bigger than 0"
+                    );
+                }
+
+                weight = value;
+            }
         }
 
         public Dictionary<string, Dictionary<string, int>> Appearance
         {
-            get; set;
+            get
+            {
+                return appearance;
+            }
+
+            set
+            {
+                if (writeOnce.isAlreadyWrite("Appearance"))
+                {
+                    throw new InvalidOperationException
+                    (
+                        "Use `'UpdateAppearance(string, string, int)`'"
+                    );
+                }
+
+                appearance = value;
+                writeOnce.AlreadyWrite("Appearance");
+            }
+        }
+
+        public void UpdateAppearance(string kind, string feature, int value)
+        {
+            if 
+            (
+                kind.Equals("unchangeable") 
+                && writeOnce.isAlreadyWrite("Appearance")
+            )
+            {
+                throw new InvalidOperationException("Value already set");
+            }
+            else
+            {
+                if 
+                (
+                    appearance.ContainsKey(kind) 
+                    && appearance[kind].ContainsKey(feature)
+                )
+                {
+                    appearance[kind][feature] = value;
+                }
+                else
+                {
+                    throw new FormatException("Invalid apperance feature");
+                }
+            }
         }
 
         public Dictionary<string, Decimal> Temperament
         {
-            get; set;
+            get
+            {
+                return temperament;
+            }
+
+            set
+            {
+                if (writeOnce.isAlreadyWrite("Temperament"))
+                {
+                    throw new InvalidOperationException("Value already set");
+                }
+
+                temperament = value;
+                writeOnce.AlreadyWrite("Temperament");
+            }
         }
     }
 }

--- a/Client/Assets/Scripts/Baby/BabyInfo.cs
+++ b/Client/Assets/Scripts/Baby/BabyInfo.cs
@@ -38,8 +38,6 @@ namespace Baby
             }
         }
 
-        // automatic property. 
-        // 보통은 private변수를 따로 두고 이에 대한 get,set을 관리하는 public property가 있음(위 ID처럼)
         public string Name
         {
             get

--- a/Client/Assets/Scripts/Module/WriteOnce.cs
+++ b/Client/Assets/Scripts/Module/WriteOnce.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Module
+{
+    public sealed class WriteOnce
+    {
+        private Dictionary<string, bool> checkSet;
+        
+        public WriteOnce()
+        {
+            checkSet = new Dictionary<string, bool>();
+        }
+        
+        public void AlreadyWrite(string feature)
+        {
+            checkSet.Add(feature, true);
+        }
+
+        public bool isAlreadyWrite(string feature)
+        {
+            return checkSet.ContainsKey(feature);
+        }
+    }
+}

--- a/Client/Assets/Scripts/Module/WriteOnce.cs.meta
+++ b/Client/Assets/Scripts/Module/WriteOnce.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d6150de9ae7ff124f9eaa9a23de59163
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Client/Assets/Scripts/Scripts.asmdef
+++ b/Client/Assets/Scripts/Scripts.asmdef
@@ -1,0 +1,3 @@
+{
+	"name": "Scripts"
+}

--- a/Client/Assets/Scripts/Scripts.asmdef.meta
+++ b/Client/Assets/Scripts/Scripts.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 36c58095dd4834a42a3e47f49f7a4d9b
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Client/Assets/Tests.meta
+++ b/Client/Assets/Tests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: de577907da9fa8d4f9fb0d940dfb6f96
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Client/Assets/Tests/BabyTest.cs
+++ b/Client/Assets/Tests/BabyTest.cs
@@ -62,33 +62,4 @@ public class BabyTest
             () => babyInfo.Temperament = temperament
         );
     }
-
-    [Test]
-    public void checkBehaviorWebRequestSendPost()
-    {
-        // BasicHttpClient http_client = 
-        //     (new GameObject("BasicHttpClient")).AddComponent();
-        // IGoedleUploadHandler goedleUploadHandler = Substitute.For();
-        // IGoedleWebRequest goedleWebRequest = Substitute.For();
-        // string stringContent = null;
-        
-        // goedleUploadHandler.add(Arg.Do(x => stringContent = x));
-        // goedleWebRequest.isHttpError.Returns(false);
-        // goedleWebRequest.isNetworkError.Returns(false);
-        // http_client
-        //     .Post
-        //     (
-        //         "http://127.0.0.1/User/SignIn",
-        //         "{\"userID\": \"1229kym\", \"userPWD\": \"abcd1234\"}", 
-        //         goedleWebRequest, 
-        //         goedleUploadHandler
-        //     );
-        // var result = JSON.Parse(stringContent);
-        // Assert.AreEqual(result["userID"].Value, "1229kym");
-        // Assert.AreEqual(result["userPWD"].Value, "abcd1234");
-        // Assert.AreEqual
-        // (
-        //     goedleWebRequest.responseCode, 204
-        // );
-    }
 }

--- a/Client/Assets/Tests/BabyTest.cs
+++ b/Client/Assets/Tests/BabyTest.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+using Baby;
+
+public class BabyTest
+{
+    [Test]
+    public void LoadingBabyTest()
+    {
+        BabyInfo babyInfo = new BabyInfo();
+        Dictionary<string, int> level = new Dictionary<string, int>();
+        Dictionary<string, Dictionary<string, int>> appearance = 
+            new Dictionary<string, Dictionary<string, int>>();
+        Dictionary<string, int> appearanceFeature = 
+            new Dictionary<string, int>();
+        Dictionary<string, Decimal> temperament = 
+            new Dictionary<string, Decimal>();
+
+        level.Add("toilet", 1);
+
+        appearanceFeature.Add("aa", 2);
+        appearance.Add("unchangeable", appearanceFeature);
+        appearance.Add("changeable", appearanceFeature);
+
+        temperament.Add("aaaa", Convert.ToDecimal(5.55));
+
+        babyInfo.ID = "aa";
+        babyInfo.Name = "bb";
+        babyInfo.Months = 5;
+        babyInfo.Level = level;
+        babyInfo.Weight = Convert.ToDecimal(4.52);
+        babyInfo.Appearance = appearance;
+        babyInfo.Temperament = temperament;
+
+        Assert.Throws<InvalidOperationException>(() => babyInfo.ID = "aaa");
+        Assert.Throws<InvalidOperationException>(() => babyInfo.Name = "aaa");
+        babyInfo.Months++;
+        Assert.AreEqual(babyInfo.Months, 6);
+        Assert.Throws<InvalidOperationException>(() => babyInfo.Level = level);
+        Assert.Throws<FormatException>(() => babyInfo.UpdateLevel("aaa", 3));
+        babyInfo.UpdateLevel("toilet", 2);
+        Assert.AreEqual(babyInfo.Level["toilet"], 2);
+        Assert.Throws<ArgumentOutOfRangeException>(() => babyInfo.Weight = -2);
+        babyInfo.Weight++;
+        Assert.AreEqual(babyInfo.Weight, Convert.ToDecimal(5.52));
+        Assert.Throws<InvalidOperationException>
+        (
+            () => babyInfo.Appearance = appearance
+        );
+        Assert.Throws<InvalidOperationException>
+        (
+            () => babyInfo.UpdateAppearance("unchangeable", "aa", 3)
+        );
+        babyInfo.UpdateAppearance("changeable", "aa", 5);
+        Assert.AreEqual(babyInfo.Appearance["changeable"]["aa"], 5);
+        Assert.Throws<InvalidOperationException>
+        (
+            () => babyInfo.Temperament = temperament
+        );
+    }
+
+    [Test]
+    public void checkBehaviorWebRequestSendPost()
+    {
+        // BasicHttpClient http_client = 
+        //     (new GameObject("BasicHttpClient")).AddComponent();
+        // IGoedleUploadHandler goedleUploadHandler = Substitute.For();
+        // IGoedleWebRequest goedleWebRequest = Substitute.For();
+        // string stringContent = null;
+        
+        // goedleUploadHandler.add(Arg.Do(x => stringContent = x));
+        // goedleWebRequest.isHttpError.Returns(false);
+        // goedleWebRequest.isNetworkError.Returns(false);
+        // http_client
+        //     .Post
+        //     (
+        //         "http://127.0.0.1/User/SignIn",
+        //         "{\"userID\": \"1229kym\", \"userPWD\": \"abcd1234\"}", 
+        //         goedleWebRequest, 
+        //         goedleUploadHandler
+        //     );
+        // var result = JSON.Parse(stringContent);
+        // Assert.AreEqual(result["userID"].Value, "1229kym");
+        // Assert.AreEqual(result["userPWD"].Value, "abcd1234");
+        // Assert.AreEqual
+        // (
+        //     goedleWebRequest.responseCode, 204
+        // );
+    }
+}

--- a/Client/Assets/Tests/BabyTest.cs.meta
+++ b/Client/Assets/Tests/BabyTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ddc9196ac765f1c47adc191799418eff
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Client/Assets/Tests/Tests.asmdef
+++ b/Client/Assets/Tests/Tests.asmdef
@@ -1,0 +1,22 @@
+{
+    "name": "Tests",
+    "rootNamespace": "",
+    "references": [
+        "UnityEngine.TestRunner",
+        "UnityEditor.TestRunner",
+        "Scripts"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": true,
+    "precompiledReferences": [],
+    "autoReferenced": false,
+    "defineConstraints": [
+        "UNITY_INCLUDE_TESTS"
+    ],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Client/Assets/Tests/Tests.asmdef.meta
+++ b/Client/Assets/Tests/Tests.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 13f256d9557e828458183e6046a423cb
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
클래스 필드에 대해 최초 한 번만 set 프로퍼티로 초기화가 가능하고, 
이후부터는 값 수정을 시도할 때마다 예외에 걸리게 함

`private readonly`로 클래스 필드를 선언해서 객체 생성 시 생성자 함수에서 초기화하려고 했지만
[여기](https://github.com/yoonmyung/RPP/blob/develop-feature/baby/Client/Assets/Scripts/Baby/LoadingBaby.cs#L47)처럼 `JsonConvert`를 사용해서 객체를 생성하기 때문에 생성자 함수를 사용할 수 없는 상황이었음

그래서 `WriteOnce` 라는 클래스 객체를 사용하기로 함
필드에서 set 프로퍼티를 호출할 때마다 이 클래스객체의 `isAlreadyWrite` 함수를 호출해서 값의 초기화 여부를 체크함