### PR TITLE
Closes #19 아기 객체 참조 코드 중복성 제거

### DIFF
--- a/Client/Assets/Scripts/Baby/LoadingBaby.cs
+++ b/Client/Assets/Scripts/Baby/LoadingBaby.cs
@@ -16,18 +16,19 @@ namespace Baby
 {
     public class LoadingBaby : MonoBehaviour
     {
-        public GameObject baby;
+        public GameObject babyPrefab;
+        public BabyObject babyObject;
         public Text date;
         public TimeController timeController;
         public SettingNamePopup settingNamePopup;
         private BabyInfo babyInfo;
 
-        public void Start()
+        private void Awake()
         {
             StartCoroutine(LoadBabyInfoCoroutine());
         }
 
-        public void Update()
+        private void Update()
         {
             try
             {
@@ -60,15 +61,17 @@ namespace Baby
                     (
                         www.downloadHandler.data
                     );
+
                 babyInfo =
                     JsonConvert.DeserializeObject<BabyInfo>(response);
-                baby =
+                babyPrefab =
                     Instantiate
                     (
-                        baby, new Vector3(0, 0, 0), Quaternion.identity
+                        babyPrefab, new Vector3(0, 0, 0), Quaternion.identity
                     );
-                baby.AddComponent<BabyObject>().Init(babyInfo);
                 RenderBaby();
+                babyPrefab.AddComponent<BabyObject>().Init(babyInfo);
+                babyObject = babyPrefab.GetComponent<BabyObject>();
             }
         }
 

--- a/Client/Assets/Scripts/Controller/MotiveController.cs
+++ b/Client/Assets/Scripts/Controller/MotiveController.cs
@@ -11,14 +11,14 @@ namespace Controller
 {
     public class MotiveController : MonoBehaviour
     {
+        public LoadingBaby loadingBaby;
         private Realm realm;
         private MotiveValue motiveValue;
-        private GameObject baby;
         private int standardofAutomaticalUpdate = 0;
         private int termOfUpdateMotive = 0;
         private bool isTantrum = false;
 
-        private void OnEnable()
+        private void Awake()
         {
             var config = new RealmConfiguration(Config.dbPath)
             {
@@ -30,7 +30,7 @@ namespace Controller
 
         private void Start()
         {
-            StartCoroutine(SetControllerCoroutine());
+            StartCoroutine(InitCoroutine());
         }
 
         private void Update()
@@ -141,23 +141,26 @@ namespace Controller
             }
         }
 
-        private IEnumerator SetControllerCoroutine()
+        private IEnumerator InitCoroutine()
         {
             yield return new WaitUntil
             (
-                () => GameObject.Find("Baby(Clone)") != null
+                () => loadingBaby.babyObject != null
             );
-            baby = GameObject.Find("Baby(Clone)");
-            var id = Guid.Parse(baby.GetComponent<BabyObject>().GetBaby().UUID);
+            
+            var id = Guid.Parse(loadingBaby.babyObject.GetBaby().UUID);
             Motive motive = realm.Find<Motive>(id);
+
             if (motive == null)
             {
                 Debug.Log("Create new motive local database");
                 double intensity =
-                    Decimal.ToDouble(baby
-                        .GetComponent<BabyObject>()
+                    Decimal.ToDouble
+                    (
+                        loadingBaby.babyObject
                         .GetBaby()
-                        .Temperament["intensity"]);
+                        .Temperament["intensity"]
+                    );
                 double motiveLackPoint = 
                     (intensity * Constants.FullMotive) % 
                     (Constants.FullMotive / 2);

--- a/Client/Assets/Scripts/Controller/TasteController.cs
+++ b/Client/Assets/Scripts/Controller/TasteController.cs
@@ -11,11 +11,11 @@ namespace Controller
 {
     public class TasteController : MonoBehaviour
     {
+        public LoadingBaby loadingBaby;
         private Realm realm;
         private Taste taste;
-        private GameObject baby;
 
-        private void OnEnable()
+        private void Awake()
         {
             var config = new RealmConfiguration(Config.dbPath)
             {
@@ -27,17 +27,23 @@ namespace Controller
 
         private void Start()
         {
-            StartCoroutine(SetControllerCoroutine());
+            StartCoroutine(InitCoroutine());
         }
 
-        private IEnumerator SetControllerCoroutine()
+        private void OnDisable()
+        {
+            realm.Dispose();
+        }
+
+        private IEnumerator InitCoroutine()
         {
             yield return new WaitUntil
             (
-                () => GameObject.Find("Baby(Clone)") != null
-            );            
-            baby = GameObject.Find("Baby(Clone)");
-            var id = Guid.Parse(baby.GetComponent<BabyObject>().GetBaby().UUID);
+                () => loadingBaby.babyObject != null
+            );
+            
+            var id = Guid.Parse(loadingBaby.babyObject.GetBaby().UUID);
+
             taste = realm.Find<Taste>(id);
             if (taste == null)
             {
@@ -47,11 +53,6 @@ namespace Controller
                     taste = realm.Add(new Taste(id));
                 });
             }
-        }
-
-        private void OnDisable()
-        {
-            realm.Dispose();
         }
     }
 }

--- a/Client/Assets/Scripts/Controller/TimeController.cs
+++ b/Client/Assets/Scripts/Controller/TimeController.cs
@@ -12,15 +12,15 @@ namespace Controller
 {
     public class TimeController : MonoBehaviour
     {
+        public LoadingBaby loadingBaby;
         public Model.Time time;
         public SteeringWheel steeringWheel;
         private Realm realm;
-        private GameObject baby;
         private int elapsedDays;
         private float elapsedTime;
         private bool isPaused;
 
-        private void OnEnable()
+        private void Awake()
         {
             var config = new RealmConfiguration(Config.dbPath)
             {
@@ -33,7 +33,7 @@ namespace Controller
 
         private void Start()
         {
-            StartCoroutine(SetControllerCoroutine());
+            StartCoroutine(InitCoroutine());
         }
 
         private void Update()
@@ -57,7 +57,7 @@ namespace Controller
                 {
                     if (elapsedDays == Constants.OneMonths)
                     {
-                        baby.GetComponent<BabyObject>().GetBaby().Months++;
+                        loadingBaby.babyObject.GetBaby().Months++;
                         elapsedDays = 0;
                     }
                 }
@@ -85,14 +85,15 @@ namespace Controller
             realm.Dispose();
         }
 
-        private IEnumerator SetControllerCoroutine()
+        private IEnumerator InitCoroutine()
         {
             yield return new WaitUntil
             (
-                () => GameObject.Find("Baby(Clone)") != null
+                () => loadingBaby.babyObject != null
             );
-            baby = GameObject.Find("Baby(Clone)");
-            var id = Guid.Parse(baby.GetComponent<BabyObject>().GetBaby().UUID);
+            
+            var id = Guid.Parse(loadingBaby.babyObject.GetBaby().UUID);
+
             time = realm.Find<Model.Time>(id);
             if (time == null)
             {
@@ -105,6 +106,6 @@ namespace Controller
 
             elapsedTime = time.CurrentTime;
             elapsedDays = time.ElapsedDays;
-        }        
+        }
     }
 }

--- a/Client/Assets/Scripts/Parenting/Outing.cs
+++ b/Client/Assets/Scripts/Parenting/Outing.cs
@@ -2,15 +2,19 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.EventSystems;
+using Baby;
 using Controller;
 
 namespace Parenting
 {
     public class Outing : MonoBehaviour
     {
-        private void Awake()
+        public LoadingBaby loadingBaby;
         public MotiveController motiveController;
+                
+        private void Start()
         {
+            StartCoroutine(InitCoroutine());
         }
         
         private void Update()
@@ -36,6 +40,22 @@ namespace Parenting
 
         private void GoOut()
         {
+        }
+
+        private IEnumerator InitCoroutine()
+        {
+            yield return new WaitUntil
+            (
+                () => loadingBaby.babyObject != null
+            );
+
+            var baby = loadingBaby.babyObject;
+            Dictionary<string, Decimal> temperament = 
+                baby.GetBaby().Temperament;
+
+            babyActivity = Decimal.ToDouble(temperament["activity"]);
+            outingProbability = 
+                new double[]{ babyActivity, 1.0f - babyActivity };
         }
     }
 }

--- a/Client/Assets/Scripts/Parenting/Toilet.cs
+++ b/Client/Assets/Scripts/Parenting/Toilet.cs
@@ -10,6 +10,7 @@ namespace Parenting
 {
     public class Toilet : MonoBehaviour
     {
+        public LoadingBaby loadingBaby;
         public Toast toastPopup;
         private bool isAvailable;
         private float timer;
@@ -18,10 +19,7 @@ namespace Parenting
 
         private void Start()
         {
-            isAvailable = true;
-            timer = 0.0f;
-            fullTime = 300.0f;
-            StartCoroutine(SetMonthsCoroutine());
+            StartCoroutine(InitCoroutine());
         }
         
         private void Update()
@@ -54,6 +52,19 @@ namespace Parenting
             }
         }
 
+        private IEnumerator InitCoroutine()
+        {
+            yield return new WaitUntil
+            (
+                () => loadingBaby.babyObject != null
+            );
+            
+            babyMonths = loadingBaby.babyObject.GetBaby().Months;
+            isAvailable = true;
+            timer = 0.0f;
+            fullTime = 300.0f;
+        }
+
         private void Pee()
         {
             if (babyMonths == Constants.MonthsofPottyTraining)
@@ -62,17 +73,6 @@ namespace Parenting
             else
             {
             }
-        }
-
-        private IEnumerator SetMonthsCoroutine()
-        {
-            yield return new WaitUntil
-            (
-                () => GameObject.Find("Baby(Clone)") != null
-            );
-            var baby = 
-                GameObject.Find("Baby(Clone)").GetComponent<BabyObject>();
-            babyMonths = baby.GetBaby().Months;
         }
     }
 }

--- a/Client/Assets/Scripts/Parenting/Washing.cs
+++ b/Client/Assets/Scripts/Parenting/Washing.cs
@@ -7,12 +7,14 @@ namespace Parenting
 {
     public class Washing : MonoBehaviour
     {
+        public LoadingBaby loadingBaby;
         public MotiveController motiveController;
 
-        private void Awake()
+        private void Start()
         {
+            StartCoroutine(InitCoroutine());
         }
-        
+
         private void Update()
         {
         }
@@ -28,7 +30,12 @@ namespace Parenting
         }
 
         private void Wash()
+        private IEnumerator InitCoroutine()
         {
+            yield return new WaitUntil
+            (
+                () => loadingBaby.babyObject != null
+            );
         }
     }
 }

--- a/Client/Assets/Scripts/UI/MealPopup.cs
+++ b/Client/Assets/Scripts/UI/MealPopup.cs
@@ -17,6 +17,7 @@ namespace UI
     {
         public Button closingButton;
         public GameObject UIelementPrefab;
+        public LoadingBaby loadingBaby;
         public Meal meal;
         private uint babyMonths;
         private List<FoodInfo> listofFoodInfo;
@@ -26,10 +27,9 @@ namespace UI
 
         private void Start()
         {
-            closingButton.onClick.AddListener(() => ClosePopUp());
             StartCoroutine(LoadFoodInfoCoroutine());
-            StartCoroutine(SetMonthsCoroutine());
-            StartCoroutine(RenderFoodCoroutine());            
+            StartCoroutine(RenderFoodCoroutine());
+            closingButton.onClick.AddListener(() => ClosePopUp());
         }
 
         public void OpenPopUp()
@@ -64,17 +64,6 @@ namespace UI
                 JsonConvert.DeserializeObject<List<FoodInfo>>(response);
         }
 
-        private IEnumerator SetMonthsCoroutine()
-        {
-            yield return new WaitUntil
-            (
-                () => GameObject.Find("Baby(Clone)") != null
-            );
-            var baby =
-                GameObject.Find("Baby(Clone)").GetComponent<BabyObject>();
-            babyMonths = baby.GetBaby().Months;
-        }
-
         private IEnumerator RenderFoodCoroutine()
         {
             yield return new WaitUntil
@@ -98,7 +87,11 @@ namespace UI
 
                 food.AddComponent<FoodObject>().Init(listofFoodInfo[i]);
                 name.GetComponent<Text>().text = listofFoodInfo[i].KoreanName;
-                if (babyMonths < listofFoodInfo[i].ProperMonths)
+                if 
+                (
+                    loadingBaby.babyObject.GetBaby().Months < 
+                    listofFoodInfo[i].ProperMonths
+                )
                 {
                     foodSprite =
                         Resources.Load<Sprite>

--- a/Client/Assets/Scripts/UI/PlayingPopup.cs
+++ b/Client/Assets/Scripts/UI/PlayingPopup.cs
@@ -17,8 +17,8 @@ namespace UI
     {
         public Button closingButton;
         public GameObject UIelementPrefab;
+        public LoadingBaby loadingBaby;
         public Playing playingGameObject;
-        private uint babyMonths;
         private List<PlayingInfo> listofPlayingInfo;
         private Sprite playingSprite;
         private float increasingRowInterval = 0f;
@@ -26,10 +26,9 @@ namespace UI
 
         private void Start()
         {
-            closingButton.onClick.AddListener(() => ClosePopUp());
             StartCoroutine(LoadPlayingInfoCoroutine());
-            StartCoroutine(SetMonthsCoroutine());
             StartCoroutine(RenderPlayingCoroutine());
+            closingButton.onClick.AddListener(() => ClosePopUp());
         }
 
         public void OpenPopUp()
@@ -64,17 +63,6 @@ namespace UI
                 JsonConvert.DeserializeObject<List<PlayingInfo>>(response);
         }
 
-        private IEnumerator SetMonthsCoroutine()
-        {
-            yield return new WaitUntil
-            (
-                () => GameObject.Find("Baby(Clone)") != null
-            );
-            var baby =
-                GameObject.Find("Baby(Clone)").GetComponent<BabyObject>();
-            babyMonths = baby.GetBaby().Months;
-        }
-
         private IEnumerator RenderPlayingCoroutine()
         {
             yield return new WaitUntil
@@ -98,7 +86,11 @@ namespace UI
 
                 playing.AddComponent<PlayingObject>().Init(listofPlayingInfo[i]);
                 name.GetComponent<Text>().text = listofPlayingInfo[i].KoreanName;
-                if (babyMonths < listofPlayingInfo[i].ProperMonths)
+                if 
+                (
+                    loadingBaby.babyObject.GetBaby().Months < 
+                    listofPlayingInfo[i].ProperMonths
+                )
                 {
                     playingSprite =
                         Resources.Load<Sprite>


### PR DESCRIPTION
유니티 생명 주기([참고](https://stickode.tistory.com/163)) 중 **Awake() -> Start()** 방식을 사용함


- **현재 게임의 생명 주기**

1. `Game Scene`이 실행([Game Scene 실행지점](https://github.com/yoonmyung/IWanit/blob/develop-feature/game/Client/Assets/Scripts/User/SignInUser.cs#L55))
2. `Assets/Scripts/User`와 `../Model` 를 제외한 대부분의 경로에서  `MonoBehaviour`를 상속한 클래스 객체가 생성됨
이때 모든 클래스는 거의 동시에 객체가 생성되기 때문에, 
객체 간 참조같은 동기적인 제어가 필요한 로직이 포함돼있을 경우 일부 상속 함수를 사용하여 실행 순서를 제어해야한다.
-내가 의도하는 순서
3. `LoadingBaby.cs`의 `LoadBabyInfoCoroutine()` 실행
4. scene에 있는 아기 객체를 참조하는 나머지 클래스의 `InitCoroutine()`초기화 함수 실행 -> 기존에는 `GameObject.Find()` 를 사용했음


- **해결 방식**

3번을 위해 `LoadBabyInfoCoroutine()`을 `Awake()` 함수로 감쌈
나머지 클래스 간에는 순서 제어가 필요하지 않기 때문에, `InitCoroutine()`을 `Start()` 함수로 감쌈
(+)`MealPopup`이나 `PlayingPopup`의 경우 사용자가 버튼을 누르기 전까지는 활성화가 되지 않으므로 순서 제어가 불필요함
그래서 Coroutine 내 `yield return new WaitUntil()` 삭제함
또한 `GameObject.Find()` 가 성능저하의 원인 중 하나임
그래서 아기 객체를 참조하는 모든 클래스는 멤버 변수로 `LoadingBaby loadingBaby`를 갖고 있게 수정함

- **코루틴 사용 이유**

-> 여기서는 `yield return new WaitUntil()` 을 사용하여 순서 제어를 하기 위함
순서 제어가 없을 경우, 3번의 `LoadBabyInfoCoroutine()` 내 로직 중 서버에서 아기 데이터를 받아오는 과정에서 딜레이가 있을 때 문제가 발생함
`LoadBabyInfoCoroutine()`이 끝나지 않은 상태에서 다른 클래스들의 `InitCoroutine()`이 실행되어, 존재하지 않는 아기 객체를 참조하려고 시도하기 때문(**Null reference exception 발생함**)
