### PR TITLE
#28 초기 셋팅 구현, #29 양치 기능 구현

### DIFF
--- a/Client/Assets/Scripts/Controller/MotiveController.cs
+++ b/Client/Assets/Scripts/Controller/MotiveController.cs
@@ -97,6 +97,40 @@ namespace Controller
         {
             return motiveValue.Urine <= motiveValue.motive.LackMotive;
         }
+
+        public void UpdateEnergy(double value)
+        {
+            motiveValue.Energy += value;
+        }
+
+        public void UpdateFun(double value)
+        {
+            motiveValue.Fun += value;
+        }
+
+        public void UpdateHunger(double value)
+        {
+            motiveValue.Hunger += value;
+        }
+
+        public void UpdateHygiene(double value)
+        {
+            motiveValue.Hygiene += value;
+        }
+
+        public void UpdateSocial(double value)
+        {
+            motiveValue.Social += value;
+        }
+
+        public void UpdateStress(double value)
+        {
+            motiveValue.Stress += value;
+        }
+
+        public void UpdateUrine(double value)
+        {
+            motiveValue.Urine += value;
         }
 
         private IEnumerator InitCoroutine()

--- a/Client/Assets/Scripts/Module/Constants.cs
+++ b/Client/Assets/Scripts/Module/Constants.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Collections;
+using UnityEngine;
 
 namespace Module
 {
@@ -19,6 +22,8 @@ namespace Module
         public const int MaxStandardtoRememberWord = 50;
 
         public const int MonthsofPottyTraining = 20;
+
+        public static readonly int[] ProperTemperatures = { 11, 17 };
         
         public const float StartingValueinRow = 0f;
         public const float StartingValueinColumn = 1f;

--- a/Client/Assets/Scripts/Module/Constants.cs
+++ b/Client/Assets/Scripts/Module/Constants.cs
@@ -24,6 +24,18 @@ namespace Module
         public const int MonthsofPottyTraining = 20;
 
         public static readonly int[] ProperTemperatures = { 11, 17 };
+        public const float ZoomIn = 300.0f;
+        public static readonly Vector2 LeftToolTransform = 
+            new Vector2(-150, 200);
+        public static readonly Vector2 RightToolTransform = 
+            new Vector2(150, 200);
+        public const int BrushingEnough = 15;
+        public const double MinimalCleanliness = 1.0f;
+
+        public static readonly Vector3 InitializedTransform = 
+            new Vector3(-270, -250, 1);
+        public static readonly Vector3 BrushingTeethTransform = 
+            new Vector3(-280, -250, 1);
         
         public const float StartingValueinRow = 0f;
         public const float StartingValueinColumn = 1f;

--- a/Client/Assets/Scripts/Parenting/Brushing.cs
+++ b/Client/Assets/Scripts/Parenting/Brushing.cs
@@ -1,0 +1,95 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+using UnityEngine.EventSystems;
+using UnityEngine.UI;
+using Module;
+using UI;
+
+namespace Parenting
+{
+    public class Brushing : MonoBehaviour, IDragHandler
+    {
+        public bool isDone;
+        public GameObject bubblePrefab;
+        public Bar bar;
+        private Vector2 originalTransform;
+        private RectTransform rectTransform;
+        private List<GameObject> generatedBubbles;
+
+        private void Start()
+        {
+            bar.gameObject.SetActive(true);
+            isDone = false;
+            generatedBubbles = new List<GameObject>();
+            rectTransform = this.GetComponent<RectTransform>();
+            originalTransform = rectTransform.anchoredPosition;
+            if (this.name.Equals("Gauze"))
+            {
+                rectTransform.anchoredPosition = Constants.LeftToolTransform;
+            }
+            else if (this.name.Equals("Toothbrush"))
+            {
+                rectTransform.anchoredPosition = Constants.RightToolTransform;
+                this.GetComponent<Button>().enabled = false;
+            }
+
+            bar.SetMaxValue(Constants.BrushingEnough);
+        }
+
+        private void Update()
+        {
+            if (bar.GetValue() >= Constants.BrushingEnough)
+            {
+                foreach (var bubble in generatedBubbles)
+                {
+                    Destroy(bubble);
+                }
+
+                bar.gameObject.SetActive(false);
+                rectTransform.anchoredPosition = originalTransform;
+                if (this.name.Equals("Toothbrush"))
+                {
+                    this.GetComponent<Button>().enabled = true;
+                }
+
+                isDone = true;
+            }
+        }
+
+        public void OnDrag(PointerEventData eventData)
+        {
+            rectTransform.anchoredPosition += eventData.delta;
+        }
+
+        private void OnCollisionEnter2D(Collision2D collision)
+        {
+            if 
+            (
+                this.name.Equals("Toothbrush") && 
+                collision.gameObject.name.Equals("Teeth") 
+                ||
+                this.name.Equals("Gauze") && 
+                collision.gameObject.name.Equals("Others")
+            )
+            {
+                foreach (ContactPoint2D contact in collision.contacts)
+                {
+                    Vector2 hitPoint = contact.point;
+                    var bubble = 
+                        Instantiate
+                        (
+                            bubblePrefab, 
+                            new Vector3(hitPoint.x, hitPoint.y, 1), 
+                            Quaternion.identity
+                        );
+
+                    generatedBubbles.Add(bubble);
+                }
+
+                bar.SetValue(bar.GetValue() + 1);
+            }
+        }
+    }
+}

--- a/Client/Assets/Scripts/Parenting/Brushing.cs.meta
+++ b/Client/Assets/Scripts/Parenting/Brushing.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6ef9076d26656224b8a4abfb838fdc84
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Client/Assets/Scripts/Parenting/Washing.cs
+++ b/Client/Assets/Scripts/Parenting/Washing.cs
@@ -1,14 +1,28 @@
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
+using UnityEngine.UI;
+using Baby;
 using Controller;
+using Module;
+using UI;
 
 namespace Parenting
 {
     public class Washing : MonoBehaviour
     {
+        public Animator steeringWheelAnimator;
+        public Animator thermometerAnimator;
+        public Animator toolsAnimator;
         public LoadingBaby loadingBaby;
         public MotiveController motiveController;
+        public GameObject thermometer;
+        public Image background;
+        public Toast toastPopup;
+        private AnimationClip currentAnimatorClip;
+        private AnimatorStateInfo currentAnimatorStateInfo;
+        private Animator babyAnimator;
 
         private void Start()
         {
@@ -17,25 +31,83 @@ namespace Parenting
 
         private void Update()
         {
+            StartCoroutine(CheckStateCoroutine());
         }
 
         private void OnMouseUpAsButton()
         {
-            Debug.Log("washing is clicked");
-            CheckAvailable();
+            if (motiveController.IsStressFull())
+            {
+                Debug.Log("Baby is under too much stress!");
+            }
+            else
+            {
+                background.sprite = 
+                    Resources.Load<Sprite>("Sprites/Background/Bathroom");
+                PrepareWashing();
+            }
         }
 
-        private void CheckAvailable()
+        public void CheckTemperature()
         {
+            thermometerAnimator.enabled = false;
+            currentAnimatorClip = 
+                thermometerAnimator.GetCurrentAnimatorClipInfo(0)[0].clip;
+            currentAnimatorStateInfo =
+                thermometerAnimator.GetCurrentAnimatorStateInfo(0);
+            var currentTemperature = 
+                (int)(
+                    currentAnimatorClip.length * 
+                    (currentAnimatorStateInfo.normalizedTime % 1) * 
+                    currentAnimatorClip.frameRate
+                );
+            
+            if (Constants.ProperTemperatures.Contains(currentTemperature))
+            {
+                var color = 
+                    new Color
+                    (
+                        babyImage.color.r, 
+                        babyImage.color.g, 
+                        babyImage.color.b, 
+                        1f
+                    );
+
+                babyAnimator.SetBool("wash", true);
+                thermometer.GetComponent<SmallerAnimation>().isDisappear = true;
+                babyImage.color = color;
+                toolsAnimator.SetBool("hidden", false);
+            }
+            else
+            {
+                toastPopup.Appear();
+                thermometerAnimator.enabled = true;
+            }
+        }
         }
 
-        private void Wash()
         private IEnumerator InitCoroutine()
         {
             yield return new WaitUntil
             (
                 () => loadingBaby.babyObject != null
             );
+        private void PrepareWashing()
+        {
+            var color = 
+                new Color
+                (
+                    babyImage.color.r, 
+                    babyImage.color.g, 
+                    babyImage.color.b, 
+                    0f
+                );
+
+            babyImage.color = color;
+            steeringWheelAnimator.SetBool("hidden", true);
+            thermometer.SetActive(true);
+        }
+
         }
     }
 }

--- a/Client/Assets/Scripts/Parenting/Washing.cs
+++ b/Client/Assets/Scripts/Parenting/Washing.cs
@@ -15,14 +15,21 @@ namespace Parenting
         public Animator steeringWheelAnimator;
         public Animator thermometerAnimator;
         public Animator toolsAnimator;
+        public List<Brushing> brushingTools;
+        public Camera camera;
         public LoadingBaby loadingBaby;
         public MotiveController motiveController;
         public GameObject thermometer;
+        public GameObject gauze;
+        public GameObject toothbrush;
         public Image background;
         public Toast toastPopup;
         private AnimationClip currentAnimatorClip;
         private AnimatorStateInfo currentAnimatorStateInfo;
         private Animator babyAnimator;
+        private float defaultOrthographicSize;
+        private Image babyImage;
+        private Image toothbrushImage;
 
         private void Start()
         {
@@ -84,6 +91,33 @@ namespace Parenting
                 thermometerAnimator.enabled = true;
             }
         }
+
+        public void PrepareBrushingTeeth()
+        {
+            babyAnimator.SetBool("brush", true);
+            camera.orthographicSize = Constants.ZoomIn;
+            loadingBaby.babyPrefab.transform.localPosition = 
+                Constants.BrushingTeethTransform;
+            gauze.SetActive(true);
+            brushingTools.ForEach(brushingTool => brushingTool.enabled = true);
+        }
+        private IEnumerator CheckStateCoroutine()
+        {
+            yield return new WaitUntil
+            (
+                () => brushingTools.All(brushingTool => brushingTool != null)
+            );
+            
+            if 
+            (
+                brushingTools.All
+                (
+                    brushingTool => brushingTool.enabled && brushingTool.isDone
+                )
+            )
+            {
+                UnloadBrushingTeeth();
+            }
         }
 
         private IEnumerator InitCoroutine()
@@ -92,6 +126,14 @@ namespace Parenting
             (
                 () => loadingBaby.babyObject != null
             );
+
+            babyImage = loadingBaby.babyPrefab.gameObject.GetComponent<Image>();
+            babyAnimator = 
+                loadingBaby.babyPrefab.gameObject.GetComponent<Animator>();
+            defaultOrthographicSize = camera.orthographicSize;
+            toothbrushImage = toothbrush.GetComponent<Image>();
+        }
+
         private void PrepareWashing()
         {
             var color = 
@@ -108,6 +150,31 @@ namespace Parenting
             thermometer.SetActive(true);
         }
 
+        private void UnloadBrushingTeeth()
+        {
+            brushingTools.ForEach(brushingTool => brushingTool.enabled = false);
+            gauze.SetActive(false);
+            loadingBaby.babyPrefab.transform.localPosition = 
+                Constants.InitializedTransform;
+            camera.orthographicSize = defaultOrthographicSize;
+            babyAnimator.SetBool("brush", false);
+            toothbrush.GetComponent<Button>().enabled = false;
+            toothbrushImage.sprite =
+                Resources.Load<Sprite>
+                (
+                    "Sprites/Washing/" + toothbrushImage.sprite.name + "_gray"
+                );
+            var cleanliness = 
+                Random.Range
+                (
+                    (float)Constants.MinimalCleanliness, 
+                    (float)Constants.FullMotive
+                );
+
+            motiveController.UpdateHygiene((double)cleanliness);
+            soapImage.sprite = enabledSoapImage; 
+            soap.GetComponent<Button>().enabled = true;
+        }
         }
     }
 }

--- a/Client/Assets/Scripts/UI/Bar.cs
+++ b/Client/Assets/Scripts/UI/Bar.cs
@@ -1,0 +1,37 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+using UnityEngine.EventSystems;
+using UnityEngine.UI;
+using Module;
+using UI;
+
+namespace UI
+{
+    public class Bar : MonoBehaviour
+    {
+        private Slider slider;
+
+        private void Awake()
+        {
+            slider = this.GetComponent<Slider>();
+            slider.value = 0;
+        }
+
+        public int GetValue()
+        {
+            return (int)slider.value;
+        }
+
+        public void SetMaxValue(int value)
+        {
+            slider.maxValue = value;
+        }
+
+        public void SetValue(int value)
+        {
+            slider.value = value;
+        }
+    }
+}

--- a/Client/Assets/Scripts/UI/Bar.cs.meta
+++ b/Client/Assets/Scripts/UI/Bar.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7af90e1cf43cd6542998de6cd239c95e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
사용자가 육아 메뉴 중 목욕 선택 시 #28 초기 셋팅을 먼저 실행함
온도계로 적정 온도를 맞추면
목욕 중 첫번째 단계인 #29 양치 기능이 활성화됨

(+) 현재는 아기의 치아 혹은 입안 콜라이더에 칫솔이나 거즈가 닿으면 바로 거품이 생기고 있음
추후에는 일정 횟수 이상 터치를 해야 거품이 생기는 식으로 수정할 예정